### PR TITLE
Fix unittests on jdk 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,19 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>add-exports</id>
+      <activation>
+        <jdk>[9,)</jdk>
+      </activation>
+      <properties>
+        <test.jvm.flags>
+          --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+          --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+        </test.jvm.flags>
+      </properties>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <junit.version>5.1.0</junit.version>
     <junit-platform.version>1.1.0</junit-platform.version>
     <opentest4j.version>1.0.0</opentest4j.version>
-    <testing-compile.version>0.19</testing-compile.version>
+    <testing-compile.version>0.21.0</testing-compile.version>
     <maven.surefire.plugin.version>2.19</maven.surefire.plugin.version>
 
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -98,6 +98,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>${test.jvm.flags}</argLine>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Newer dependency should not result in errors like `cannot access class com.sun.tools.javac.api.JavacTool`.
Additional JVM flags are needed while running these tests however.