### PR TITLE
Fix CI: bump aerius/github-actions to v1.1 (deprecated actions/cache@v1)

### DIFF
--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
       - name: Check out github-actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: aerius/github-actions
           path: aerius-github-actions
-          ref: v1.0.2
+          ref: v1.1
 
-      - uses: aerius/github-actions/events/pull_request-event-action@v1.0.2
+      - uses: aerius/github-actions/events/pull_request-event-action@v1.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JDK_VERSION: 17

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -9,13 +9,13 @@ jobs:
 
     steps:
       - name: Check out github-actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: aerius/github-actions
           path: aerius-github-actions
-          ref: v1.0.2
+          ref: v1.1
 
-      - uses: aerius/github-actions/events/push-event-action@v1.0.2
+      - uses: aerius/github-actions/events/push-event-action@v1.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXUS_USERNAME: ${{ vars.NEXUS_USERNAME }}

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -10,13 +10,13 @@ jobs:
 
     steps:
       - name: Check out github-actions repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: aerius/github-actions
           path: aerius-github-actions
-          ref: v1.0.2
+          ref: v1.1
 
-      - uses: aerius/github-actions/events/release-event-action@v1.0.2
+      - uses: aerius/github-actions/events/release-event-action@v1.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXUS_USERNAME: ${{ vars.NEXUS_USERNAME }}


### PR DESCRIPTION
GitHub now hard-fails runs using actions/cache@v1, pulled in by aerius/github-actions@v1.0.2. The v1.1 branch uses actions/cache@v4.

- Bump all three workflows from @v1.0.2 to @v1.1
- Bump local actions/checkout@v2 to @v4 (clears Node.js 20 warning)