### PR TITLE
Use newer maven-shade-plugin version

### DIFF
--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -105,7 +105,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
With newer actions, the publish part fails because the maven-shade-plugin detects a duplicate entry in `META-INF/services`. That has since been fixed in the plugin (see https://github.com/elastic/apm-agent-java/issues/961), so switching to the latest version of the plugin should fix it (locally it does look that way).